### PR TITLE
Fix XmlSerializer memory leak by implementing caching

### DIFF
--- a/ihcclient/src/util/serialize.cs
+++ b/ihcclient/src/util/serialize.cs
@@ -78,7 +78,7 @@ namespace Ihc {
                     .FirstOrDefault(p => true) as XmlSerializerNamespaces;
 
 
-        var xmlSerializer = GetOrCreateSerializer(typeof(A), attrs);
+        var xmlSerializer = GetOrCreateSerializer(typeof(A), attrs, genericTypes);
         var settings = new XmlWriterSettings() { OmitXmlDeclaration = true, Indent = true, Encoding = new UTF8Encoding(false), NamespaceHandling = NamespaceHandling.OmitDuplicates };
 
         using (var stream = new MemoryStream())

--- a/ihcclient/src/util/serialize.cs
+++ b/ihcclient/src/util/serialize.cs
@@ -29,30 +29,31 @@ namespace Ihc {
         }
         if (extraTypes != null && extraTypes.Length > 0)
         {
-            key += "_extraTypes_" + string.Join("_", extraTypes.Select(t => t.Name));
+            key += "_extraTypes_" + string.Join("_", extraTypes.Select(t => t.FullName ?? t.Name));
         }
         return key;
     }
 
+    // Make sure XmlSerializers are reused to avoid memory leak. See also github issue #2
     private static XmlSerializer GetOrCreateSerializer(Type type, XmlAttributeOverrides attrs, Type[] extraTypes = null)
     {
-        var key = GetSerializerKey(type, attrs, extraTypes);
+      var key = GetSerializerKey(type, attrs, extraTypes);
 
-        return serializerCache.GetOrAdd(key, k =>
+      return serializerCache.GetOrAdd(key, k =>
+      {
+        if (extraTypes != null && extraTypes.Length > 0)
         {
-            if (extraTypes != null && extraTypes.Length > 0)
-            {
-                return new XmlSerializer(type, attrs, extraTypes, null, null);
-            }
-            else if (attrs != null)
-            {
-                return new XmlSerializer(type, attrs);
-            }
-            else
-            {
-                return new XmlSerializer(type);
-            }
-        });
+          return new XmlSerializer(type, attrs, extraTypes, null, null);
+        }
+        else if (attrs != null)
+        {
+          return new XmlSerializer(type, attrs);
+        }
+        else
+        {
+          return new XmlSerializer(type);
+        }
+      });
     }
     public static string SerializeXml<A>(A x) where A : class {    
       try {    

--- a/ihcclient_tests/SerializationUnitTest.cs
+++ b/ihcclient_tests/SerializationUnitTest.cs
@@ -71,7 +71,7 @@ namespace Ihc.Tests
           return Regex.Replace(str, @"\s", "");
         }
 
-
+        #region High level tests
         [Test]
         public void SerializeRequestXml()
         {
@@ -109,7 +109,9 @@ namespace Ihc.Tests
           ComparisonResult compare = compareLogic.Compare(o, getAllDatalineInputsObject);
           Assert.True(compare.AreEqual);
         }
-
+        #endregion
+        
+        #region Low level tests
         [Test]
         public void GetOrCreateSerializer_ShouldReuseSerializer_ForSameType()
         {
@@ -208,6 +210,6 @@ namespace Ihc.Tests
             var method = typeof(Serialization).GetMethod("GetOrCreateSerializer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
             return (System.Xml.Serialization.XmlSerializer)method.Invoke(null, new object[] { type, attrs, extraTypes });
         }
+        #endregion
     }
-
 }

--- a/ihcclient_tests/SerializationUnitTest.cs
+++ b/ihcclient_tests/SerializationUnitTest.cs
@@ -109,6 +109,105 @@ namespace Ihc.Tests
           ComparisonResult compare = compareLogic.Compare(o, getAllDatalineInputsObject);
           Assert.True(compare.AreEqual);
         }
+
+        [Test]
+        public void GetOrCreateSerializer_ShouldReuseSerializer_ForSameType()
+        {
+            var type = typeof(RequestEnvelope<Ihc.Soap.Authentication.inputMessageName2>);
+            var attrs = new System.Xml.Serialization.XmlAttributeOverrides();
+
+            var serializer1 = GetOrCreateSerializerAccessor(type, attrs, null);
+            var serializer2 = GetOrCreateSerializerAccessor(type, attrs, null);
+
+            Assert.That(serializer2, Is.SameAs(serializer1), "Serializer should be reused for same type and attributes");
+        }
+
+        [Test]
+        public void GetOrCreateSerializer_ShouldReuseSerializer_ForSameTypeWithoutAttributes()
+        {
+            var type = typeof(ResponseEnvelope<Ihc.Soap.Openapi.outputMessageName11>);
+
+            var serializer1 = GetOrCreateSerializerAccessor(type, null, null);
+            var serializer2 = GetOrCreateSerializerAccessor(type, null, null);
+
+            Assert.That(serializer2, Is.SameAs(serializer1), "Serializer should be reused for same type without attributes");
+        }
+
+        [Test]
+        public void GetOrCreateSerializer_ShouldReuseSerializer_ForSameTypeWithExtraTypes()
+        {
+            var type = typeof(ResponseEnvelope<Ihc.Soap.Resourceinteraction.outputMessageName12>);
+            var attrs = new System.Xml.Serialization.XmlAttributeOverrides();
+            var extraTypes = new Type[] { typeof(Ihc.Soap.Resourceinteraction.WSDatalineResource) };
+
+            var serializer1 = GetOrCreateSerializerAccessor(type, attrs, extraTypes);
+            var serializer2 = GetOrCreateSerializerAccessor(type, attrs, extraTypes);
+
+            Assert.That(serializer2, Is.SameAs(serializer1), "Serializer should be reused for same type with extra types");
+        }
+
+        [Test]
+        public void GetOrCreateSerializer_ShouldCreateDifferentSerializers_ForDifferentTypes()
+        {
+            var type1 = typeof(RequestEnvelope<Ihc.Soap.Authentication.inputMessageName2>);
+            var type2 = typeof(ResponseEnvelope<Ihc.Soap.Openapi.outputMessageName11>);
+            var attrs = new System.Xml.Serialization.XmlAttributeOverrides();
+
+            var serializer1 = GetOrCreateSerializerAccessor(type1, attrs, null);
+            var serializer2 = GetOrCreateSerializerAccessor(type2, attrs, null);
+
+            Assert.That(serializer2, Is.Not.SameAs(serializer1), "Different types should have different serializers");
+        }
+
+        [Test]
+        public void GetOrCreateSerializer_ShouldCreateDifferentSerializers_ForSameTypeWithDifferentAttributes()
+        {
+            var type = typeof(RequestEnvelope<Ihc.Soap.Authentication.inputMessageName2>);
+
+            var serializer1 = GetOrCreateSerializerAccessor(type, null, null);
+            var serializer2 = GetOrCreateSerializerAccessor(type, new System.Xml.Serialization.XmlAttributeOverrides(), null);
+
+            Assert.That(serializer2, Is.Not.SameAs(serializer1), "Same type with different attribute configurations should have different serializers");
+        }
+
+        [Test]
+        public void GetOrCreateSerializer_ShouldCreateDifferentSerializers_ForSameTypeWithDifferentExtraTypes()
+        {
+            var type = typeof(ResponseEnvelope<Ihc.Soap.Resourceinteraction.outputMessageName12>);
+            var attrs = new System.Xml.Serialization.XmlAttributeOverrides();
+            var extraTypes1 = new Type[] { typeof(Ihc.Soap.Resourceinteraction.WSDatalineResource) };
+            var extraTypes2 = new Type[] { typeof(Ihc.Soap.Authentication.WSAuthenticationData) };
+
+            var serializer1 = GetOrCreateSerializerAccessor(type, attrs, extraTypes1);
+            var serializer2 = GetOrCreateSerializerAccessor(type, attrs, extraTypes2);
+
+            Assert.That(serializer2, Is.Not.SameAs(serializer1), "Same type with different extra types should have different serializers");
+        }
+
+        [Test]
+        public void GetOrCreateSerializer_ShouldHandleConcurrentAccess()
+        {
+            var type = typeof(RequestEnvelope<Ihc.Soap.Authentication.inputMessageName2>);
+            var attrs = new System.Xml.Serialization.XmlAttributeOverrides();
+            var serializers = new System.Xml.Serialization.XmlSerializer[10];
+
+            Parallel.For(0, 10, i =>
+            {
+                serializers[i] = GetOrCreateSerializerAccessor(type, attrs, null);
+            });
+
+            var firstSerializer = serializers[0];
+            for (int i = 1; i < 10; i++)
+            {
+                Assert.That(serializers[i], Is.SameAs(firstSerializer), $"All concurrent accesses should return the same serializer instance (index {i})");
+            }
+        }
+
+        private System.Xml.Serialization.XmlSerializer GetOrCreateSerializerAccessor(Type type, System.Xml.Serialization.XmlAttributeOverrides attrs, Type[] extraTypes)
+        {
+            var method = typeof(Serialization).GetMethod("GetOrCreateSerializer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            return (System.Xml.Serialization.XmlSerializer)method.Invoke(null, new object[] { type, attrs, extraTypes });
+        }
     }
 
 }


### PR DESCRIPTION
Addresses issue #2 - Memory leak in XmlSerializer

The XmlSerializer constructors that accept XmlAttributeOverrides or extraTypes generate dynamic assemblies that are never garbage collected, causing memory leaks especially problematic on memory-constrained systems.

This fix implements Microsoft's recommended approach by caching XmlSerializer instances in a ConcurrentDictionary to ensure they are reused rather than recreated on each serialization/deserialization call.

Changes:
- Added static ConcurrentDictionary to cache XmlSerializer instances
- Added GetSerializerKey() method to generate unique cache keys
- Added GetOrCreateSerializer() method to retrieve or create cached serializers
- Updated SerializeXml() and DeserializeXml() to use cached serializers